### PR TITLE
Use registry export

### DIFF
--- a/CPU/Combo.ini
+++ b/CPU/Combo.ini
@@ -24,46 +24,39 @@ GraphColor3=#BlueThird#
 ; MEASURES
 
 [CpuName]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_CpuSensorId#
-HWiNFOSensorInstance=#HW_CpuSensorInstance#
-HWiNFOType=SensorName
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=Sensor0
 RegExpSubstitute=1
 Substitute="^(.*]: )":"","(: .*)$":""
 UpdateDivider=36000
 
 [CpuUsage]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_CpuSensorId#
-HWiNFOSensorInstance=#HW_CpuSensorInstance#
-HWiNFOEntryId=#HW_CpuUsage#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRaw0
 OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter Value]
 UpdateDivider=10
 MinValue=0
 MaxValue=100
 
 [CpuTemperature]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_CpuDtsSensorId#
-HWiNFOSensorInstance=#HW_CpuDtsSensorInstance#
-HWiNFOEntryId=#HW_CpuTemperature#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRaw1
 OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter Value2]
 UpdateDivider=10
 MinValue=0
 MaxValue=100
 
 [CpuFan]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_CpuMoboSensorId#
-HWiNFOSensorInstance=#HW_CpuMoboSensorInstance#
-HWiNFOEntryId=#HW_CpuFan#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRaw2
 OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter Value3]
 UpdateDivider=10
 MinValue=0

--- a/CPU/Combo.ini
+++ b/CPU/Combo.ini
@@ -8,7 +8,7 @@ Name=CPU Combination
 Author=Peter Han
 Information=Displays all CPU metrics in one
 License=Creative Commons BY-NC-SA 4.0
-Version=0.3.1
+Version=0.4.0
 
 
 [Variables]

--- a/CPU/Fan.ini
+++ b/CPU/Fan.ini
@@ -8,7 +8,7 @@ Name=CPU Fan Usage
 Author=Peter Han
 Information="Displays CPU Fan's RPM"
 License=Creative Commons BY-NC-SA 4.0
-Version=0.3.1
+Version=0.4.0
 
 
 [Variables]

--- a/CPU/Fan.ini
+++ b/CPU/Fan.ini
@@ -6,7 +6,7 @@ DefaultUpdateDivider=-1
 [Metadata]
 Name=CPU Fan Usage
 Author=Peter Han
-Information=Displays CPU Fan's RPM
+Information="Displays CPU Fan's RPM"
 License=Creative Commons BY-NC-SA 4.0
 Version=0.3.1
 
@@ -20,22 +20,19 @@ GraphColor=#Blue#
 ; MEASURES
 
 [CpuName]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_CpuSensorId#
-HWiNFOSensorInstance=#HW_CpuSensorInstance#
-HWiNFOType=SensorName
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=Sensor0
 RegExpSubstitute=1
 Substitute="^(.*]: )":"","(: .*)$":""
 UpdateDivider=36000
 
 [CpuFan]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_CpuMoboSensorId#
-HWiNFOSensorInstance=#HW_CpuMoboSensorInstance#
-HWiNFOEntryId=#HW_CpuFan#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRaw2
 OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter GraphBackground][!UpdateMeter Value]
 UpdateDivider=10
 MinValue=0

--- a/CPU/Temperature.ini
+++ b/CPU/Temperature.ini
@@ -20,22 +20,19 @@ GraphColor=#Blue#
 ; MEASURES
 
 [CpuName]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_CpuDtsSensorId#
-HWiNFOSensorInstance=#HW_CpuDtsSensorInstance#
-HWiNFOType=SensorName
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=Sensor0
 RegExpSubstitute=1
 Substitute="^(.*]: )":"","(: .*)$":""
 UpdateDivider=36000
 
 [CpuTemperature]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_CpuDtsSensorId#
-HWiNFOSensorInstance=#HW_CpuDtsSensorInstance#
-HWiNFOEntryId=#HW_CpuTemperature#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRaw1
 OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter GraphBackground][!UpdateMeter Value]
 UpdateDivider=10
 MinValue=0

--- a/CPU/Temperature.ini
+++ b/CPU/Temperature.ini
@@ -8,7 +8,7 @@ Name=CPU Temperature
 Author=Peter Han
 Information=Displays CPU Temperature
 License=Creative Commons BY-NC-SA 4.0
-Version=0.3.1
+Version=0.4.0
 
 
 [Variables]

--- a/CPU/Usage.ini
+++ b/CPU/Usage.ini
@@ -8,7 +8,7 @@ Name=CPU Usage
 Author=Peter Han
 Information=Displays CPU usage
 License=Creative Commons BY-NC-SA 4.0
-Version=0.3.1
+Version=0.4.0
 
 
 [Variables]

--- a/CPU/Usage.ini
+++ b/CPU/Usage.ini
@@ -20,22 +20,19 @@ GraphColor=#Blue#
 ; MEASURES
 
 [CpuName]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_CpuSensorId#
-HWiNFOSensorInstance=#HW_CpuSensorInstance#
-HWiNFOType=SensorName
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=Sensor0
 RegExpSubstitute=1
 Substitute="^(.*]: )":"","(: .*)$":""
 UpdateDivider=36000
 
 [CpuUsage]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_CpuSensorId#
-HWiNFOSensorInstance=#HW_CpuSensorInstance#
-HWiNFOEntryId=#HW_CpuUsage#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRaw0
 OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter GraphBackground][!UpdateMeter Value]
 UpdateDivider=10
 MinValue=0

--- a/GPU/Combo.ini
+++ b/GPU/Combo.ini
@@ -8,7 +8,7 @@ Name=GPU Combination
 Author=Peter Han
 Information=Displays all GPU metrics in one
 License=Creative Commons BY-NC-SA 4.0
-Version=0.3.1
+Version=0.4.0
 
 
 [Variables]

--- a/GPU/Combo.ini
+++ b/GPU/Combo.ini
@@ -24,46 +24,39 @@ GraphColor3=#GreenThird#
 ; MEASURES
 
 [GpuName]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_GpuSensorId#
-HWiNFOSensorInstance=#HW_GpuSensorInstance#
-HWiNFOType=SensorName
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=Sensor3
 RegExpSubstitute=1
 Substitute="^(.*]: )":"","(: .*)$":""
 UpdateDivider=36000
 
 [GpuUsage]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_GpuSensorId#
-HWiNFOSensorInstance=#HW_GpuSensorInstance#
-HWiNFOEntryId=#HW_GpuUsage#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRaw5
 OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter Value]
 UpdateDivider=10
 MinValue=0
 MaxValue=100
 
 [GpuTemperature]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_GpuSensorId#
-HWiNFOSensorInstance=#HW_GpuSensorInstance#
-HWiNFOEntryId=#HW_GpuTemperature#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRaw3
 OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter Value2]
 UpdateDivider=10
 MinValue=0
 MaxValue=100
 
 [GpuFan]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_GpuSensorId#
-HWiNFOSensorInstance=#HW_GpuSensorInstance#
-HWiNFOEntryId=#HW_GpuFan#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRaw4
 OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter Value3]
 UpdateDivider=10
 MinValue=0

--- a/GPU/Fan.ini
+++ b/GPU/Fan.ini
@@ -6,7 +6,7 @@ DefaultUpdateDivider=-1
 [Metadata]
 Name=GPU Fan Usage
 Author=Peter Han
-Information=Displays GPU Fan's RPM
+Information="Displays GPU Fan's RPM"
 License=Creative Commons BY-NC-SA 4.0
 Version=0.3.1
 
@@ -20,22 +20,19 @@ GraphColor=#Green#
 ; MEASURES
 
 [GpuName]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_GpuSensorId#
-HWiNFOSensorInstance=#HW_GpuSensorInstance#
-HWiNFOType=SensorName
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=Sensor3
 RegExpSubstitute=1
 Substitute="^(.*]: )":"","(: .*)$":""
 UpdateDivider=36000
 
 [GpuFan]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_GpuSensorId#
-HWiNFOSensorInstance=#HW_GpuSensorInstance#
-HWiNFOEntryId=#HW_GpuFan#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRaw4
 OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter GraphBackground][!UpdateMeter Value]
 UpdateDivider=10
 MinValue=0

--- a/GPU/Fan.ini
+++ b/GPU/Fan.ini
@@ -8,7 +8,7 @@ Name=GPU Fan Usage
 Author=Peter Han
 Information="Displays GPU Fan's RPM"
 License=Creative Commons BY-NC-SA 4.0
-Version=0.3.1
+Version=0.4.0
 
 
 [Variables]

--- a/GPU/Temperature.ini
+++ b/GPU/Temperature.ini
@@ -8,7 +8,7 @@ Name=GPU Temperature
 Author=Peter Han
 Information=Displays GPU Temperature
 License=Creative Commons BY-NC-SA 4.0
-Version=0.3.1
+Version=0.4.0
 
 
 [Variables]

--- a/GPU/Temperature.ini
+++ b/GPU/Temperature.ini
@@ -20,22 +20,19 @@ GraphColor=#Green#
 ; MEASURES
 
 [GpuName]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_GpuSensorId#
-HWiNFOSensorInstance=#HW_GpuSensorInstance#
-HWiNFOType=SensorName
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=Sensor3
 RegExpSubstitute=1
 Substitute="^(.*]: )":"","(: .*)$":""
 UpdateDivider=36000
 
 [GpuTemperature]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_GpuSensorId#
-HWiNFOSensorInstance=#HW_GpuSensorInstance#
-HWiNFOEntryId=#HW_GpuTemperature#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRaw3
 OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter GraphBackground][!UpdateMeter Value]
 UpdateDivider=10
 MinValue=0

--- a/GPU/Usage.ini
+++ b/GPU/Usage.ini
@@ -20,22 +20,19 @@ GraphColor=#Green#
 ; MEASURES
 
 [GpuName]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_GpuSensorId#
-HWiNFOSensorInstance=#HW_GpuSensorInstance#
-HWiNFOType=SensorName
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=Sensor3
 RegExpSubstitute=1
 Substitute="^(.*]: )":"","(: .*)$":""
 UpdateDivider=36000
 
 [GpuUsage]
-Measure=Plugin
-Plugin=HWiNFO.dll
-HWiNFOSensorId=#HW_GpuSensorId#
-HWiNFOSensorInstance=#HW_GpuSensorInstance#
-HWiNFOEntryId=#HW_GpuUsage#
-HWiNFOType=CurrentValue
+Measure=Registry
+RegHKey=HKEY_CURRENT_USER
+RegKey=SOFTWARE\HWiNFO64\VSB
+RegValue=ValueRaw5
 OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter GraphBackground][!UpdateMeter Value]
 UpdateDivider=10
 MinValue=0

--- a/GPU/Usage.ini
+++ b/GPU/Usage.ini
@@ -8,7 +8,7 @@ Name=GPU Usage
 Author=Peter Han
 Information=Displays GPU usage
 License=Creative Commons BY-NC-SA 4.0
-Version=0.3.1
+Version=0.4.0
 
 
 [Variables]

--- a/Memory/Bytes.ini
+++ b/Memory/Bytes.ini
@@ -8,7 +8,7 @@ Name=Memory Bytes
 Author=Peter Han
 Information=Displays used memory in bytes
 License=Creative Commons BY-NC-SA 4.0
-Version=0.3.1
+Version=0.4.0
 
 
 [Variables]

--- a/Memory/Combo.ini
+++ b/Memory/Combo.ini
@@ -8,7 +8,7 @@ Name=Memory Combination
 Author=Peter Han
 Information=Displays all memory metrics in one
 License=Creative Commons BY-NC-SA 4.0
-Version=0.3.1
+Version=0.4.0
 
 
 [Variables]

--- a/Memory/Percentage.ini
+++ b/Memory/Percentage.ini
@@ -8,7 +8,7 @@ Name=Memory Percentage
 Author=Peter Han
 Information=Displays used memory in percentages
 License=Creative Commons BY-NC-SA 4.0
-Version=0.3.1
+Version=0.4.0
 
 
 [Variables]


### PR DESCRIPTION
This PR updates the metrics so that they are no longer depending on HWInfo's shared memory. Instead it makes use of the HWInfo's Windows Registry export of the metrics.

This PR also increment the minor version so it can be tagged.