### PR TITLE
feat: add Network metric widget

### DIFF
--- a/Network/Combo.ini
+++ b/Network/Combo.ini
@@ -1,0 +1,57 @@
+[Rainmeter]
+Update=100
+DefaultUpdateDivider=-1
+
+
+[Metadata]
+Name=Network Combination
+Author=Peter Han
+Information=Displays all network metrics in one
+License=Creative Commons BY-NC-SA 4.0
+Version=0.4.0
+
+
+[Variables]
+@Include1=#@#comboTemplate.ini
+GraphMeasure=NetworkDownload
+GraphMeasure2=NetworkUpload
+GraphColor=#Yellow#
+GraphColor2=#YellowThird#
+
+
+; MEASURES
+
+[NetworkDownload]
+Measure=NetIn
+OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter Value]
+UpdateDivider=10
+
+[NetworkUpload]
+Measure=NetOut
+OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter Value2]
+UpdateDivider=10
+
+
+; METERS
+
+[Graph]
+LineCount=2
+AutoScale=1
+
+[Label]
+Text="Network"
+
+[Value]
+Text="DL: %1B/s"
+; AutoScale automatically appends 'k', 'M', or 'G' based on speed.
+AutoScale=1
+NumOfDecimals=1
+
+[Value2]
+Text="UP: %1B/s"
+; AutoScale automatically appends 'k', 'M', or 'G' based on speed.
+AutoScale=1
+NumOfDecimals=1
+
+[Value3]
+Hidden=1

--- a/Network/Download.ini
+++ b/Network/Download.ini
@@ -1,0 +1,43 @@
+[Rainmeter]
+Update=100
+DefaultUpdateDivider=-1
+
+
+[Metadata]
+Name=Network Download
+Author=Peter Han
+Information=Displays network download rate
+License=Creative Commons BY-NC-SA 4.0
+Version=0.4.0
+
+
+[Variables]
+@Include1=#@#template.ini
+GraphMeasure=NetworkDownload
+GraphColor=#Yellow#
+
+
+; MEASURES
+
+[NetworkDownload]
+Measure=NetIn
+OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter GraphBackground][!UpdateMeter Value]
+UpdateDivider=10
+
+
+; METERS
+
+[Label]
+Text="Network"
+
+[Value]
+Text="%1B/s"
+; AutoScale automatically appends 'k', 'M', or 'G' based on speed.
+AutoScale=1
+NumOfDecimals=2
+
+
+; GRAPHS
+
+[Graph]
+AutoScale=1

--- a/Network/Upload.ini
+++ b/Network/Upload.ini
@@ -1,0 +1,43 @@
+[Rainmeter]
+Update=100
+DefaultUpdateDivider=-1
+
+
+[Metadata]
+Name=Network Upload
+Author=Peter Han
+Information=Displays network upload rate
+License=Creative Commons BY-NC-SA 4.0
+Version=0.4.0
+
+
+[Variables]
+@Include1=#@#template.ini
+GraphMeasure=NetworkUpload
+GraphColor=#Yellow#
+
+
+; MEASURES
+
+[NetworkUpload]
+Measure=NetOut
+OnUpdateAction=[!UpdateMeter Graph][!UpdateMeter GraphBackground][!UpdateMeter Value]
+UpdateDivider=10
+
+
+; METERS
+
+[Label]
+Text="Network"
+
+[Value]
+Text="%1B/s"
+; AutoScale automatically appends 'k', 'M', or 'G' based on speed.
+AutoScale=1
+NumOfDecimals=2
+
+
+; GRAPHS
+
+[Graph]
+AutoScale=1


### PR DESCRIPTION
## Summary
- Add `Network/` widget family (Download, Upload, Combo) mirroring the existing CPU/GPU/Memory structure
- Uses the unused Yellow color family; standalone skins reuse `NetIn`/`NetOut` measures with `AutoScale`
- Combo fixes a label/color crossing found while cleaning up the draft (DL now maps to Yellow, UP to YellowThird)

## Testing
- Rainmeter skin (Windows-only); cannot execute locally on macOS
- Verified structurally: section layout diffed against `CPU/Usage.ini` and `Memory/Combo.ini`, all `OnUpdateAction`/`MeasureName` references resolve, colors exist in `@Resources/variables.ini`, version bumped to `0.4.0` to match siblings