### PR TITLE
feat: redesign box layout with name on top, 70% wide graph

### DIFF
--- a/@Resources/template.ini
+++ b/@Resources/template.ini
@@ -5,10 +5,11 @@
 [Variables]
 @Include1="#@#variables.ini"
 @Include2="#@#background.ini"
-GraphLeftPadding=10
-GraphTopPadding=10
-GraphWidth=130
-GraphHeight=(#BackgroundHeight# - (#GraphTopPadding# * 2))
+OuterPadding=12
+NameHeight=22
+RowGap=8
+GraphWidth=(#BackgroundWidth# * 0.7)
+GraphHeight=(#BackgroundHeight# - (#OuterPadding# * 2) - #NameHeight# - #RowGap#)
 
 ; To be overriden
 GraphMeasure=PlaceholderMeasure
@@ -29,8 +30,8 @@ UpdateDivider=-1
 Meter=Line
 ; To be overriden
 MeasureName=#GraphMeasure#
-X=(#GraphLeftPadding# + 1)
-Y=(#GraphTopPadding# + 1)
+X=(#OuterPadding# + 1)
+Y=(#OuterPadding# + #NameHeight# + #RowGap# + 1)
 W=(#GraphWidth# - 1)
 H=(#GraphHeight# - 2)
 AntiAlias=1
@@ -55,8 +56,8 @@ UpdateDivider=-1
 ; Borders of the graph
 [Top]
 Meter=Image
-X=#GraphLeftPadding#
-Y=#GraphTopPadding#
+X=#OuterPadding#
+Y=(#OuterPadding# + #NameHeight# + #RowGap#)
 W=#GraphWidth#
 H=1
 SolidColor=#GraphColor#
@@ -94,9 +95,10 @@ UpdateDivider=-1
 Meter=String
 ; To be overriden
 Text="Label"
-X=#GraphLeftPadding#R
-Y=0r
-W=(#BackgroundWidth# - #GraphWidth# - (#GraphLeftPadding# * 2))
+X=#OuterPadding#
+Y=#OuterPadding#
+W=(#BackgroundWidth# - (#OuterPadding# * 2))
+H=#NameHeight#
 AntiAlias=1
 FontSize=11
 FontColor=#White#
@@ -109,8 +111,9 @@ Meter=String
 MeasureName=#GraphMeasure#
 Text="%1"
 NumOfDecimals=0
-X=5r
-Y=0R
+X=(#OuterPadding# + #GraphWidth# + #RowGap#)
+Y=(#OuterPadding# + #NameHeight# + #RowGap#)
+W=(#BackgroundWidth# - (#OuterPadding# * 2) - #GraphWidth# - #RowGap#)
 AntiAlias=1
 FontSize=9
 FontColor=#Grey#

--- a/@Resources/variables.ini
+++ b/@Resources/variables.ini
@@ -5,8 +5,8 @@
 [Variables]
 
 ; Basic layout set up
-BackgroundWidth=300
-BackgroundHeight=80
+BackgroundWidth=380
+BackgroundHeight=130
 BackgroundColor=27,27,27,204
 BorderColor=51,51,51
 


### PR DESCRIPTION
## Summary
- Name label now spans the full box width on top
- Graph and value text moved below, graph fixed at 70% of box width
- Box enlarged to 380x130 (from 300x80) to fit the new layout

## Testing
Not tested in Rainmeter (Windows-only runtime, unavailable in this environment). Verified layout math by hand: GraphWidth=266 (exactly 70% of 380), GraphHeight=76, value column X=286/W=82, no leftover references to removed variables. Please confirm visually once loaded in Rainmeter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)