### PR TITLE
ci: fix release upload path mismatch, DRY build/package dirs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      PKG_DIR: package
+      OUT_DIR: build
     permissions:
       contents: write # needed for the tag-gated release step; harmless otherwise
     steps:
@@ -19,9 +22,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Stage package layout
         run: |
-          mkdir -p build/pkg/Skins/rainmeter
-          cp -R CPU GPU Memory Network @Resources build/pkg/Skins/rainmeter/
-          cat > build/pkg/RMSKIN.ini <<'EOF'
+          mkdir -p "$PKG_DIR/Skins/rainmeter" "$OUT_DIR"
+          cp -R CPU GPU Memory Network @Resources "$PKG_DIR/Skins/rainmeter/"
+          cat > "$PKG_DIR/RMSKIN.ini" <<'EOF'
           [rmskin]
           Author=Peter Han
           LoadType=Skin
@@ -43,15 +46,15 @@ jobs:
         id: builder
         uses: 2bndy5/rmskin-action@cefb988ebf291b17d3d4dc442d3ac8cb162dde64 # v2.0.4
         with:
-          path: build/pkg
-          dir-out: build
+          path: ${{ env.PKG_DIR }}
+          dir-out: ${{ env.OUT_DIR }}
           title: rainmeter
           version: ${{ steps.version.outputs.version }}
       - name: Publish to release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          files: ${{ steps.builder.outputs.arc-name }}
+          files: ${{ env.OUT_DIR }}/${{ steps.builder.outputs.arc-name }}
           generate_release_notes: true
           fail_on_unmatched_files: true
 


### PR DESCRIPTION
## Summary
- Fixes the `0.5.0` tag release failure ("Pattern does not match any files") — `rmskin-action`'s `arc-name` output is a bare filename, but the archive lands in the `dir-out` directory, so the release-upload glob never matched.
- Introduces `package/` as the staging input dir (renamed from `build/pkg`) and keeps `build/` as the output dir.
- Adds job-level `env: PKG_DIR`, `OUT_DIR` so both directory names are defined once and can't drift out of sync across the staging, build, and release steps.

## Testing
- Validated workflow YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"`).
- Ran `ci-reviewer` and `security-reviewer` subagents against the diff — both approved with no blocking findings (one informational LOW noted: theoretical glob widening in `files:` if `arc-name` ever contained a glob metacharacter; not exploitable here since it's derived from a static title + tag ref-name, not attacker input).
- Not yet exercised end-to-end: the release-upload step only runs on `refs/tags/*` pushes, so this PR's own CI run will prove staging + packaging against the new `package/` layout, but the actual release-attach fix can only be confirmed by re-running the `0.5.0` tag release after merge.